### PR TITLE
Optimized the database function related to real time search using FTS, and added an LRU cache with a TTL mechanism.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,14 @@
             <version>10.2.0</version>
         </dependency>
 
+        <!-- Cache -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
+        </dependency>
+
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/sherlook/search/indexer/Indexer.java
+++ b/src/main/java/com/sherlook/search/indexer/Indexer.java
@@ -97,6 +97,17 @@ public class Indexer {
         ConsoleColors.printInfo("Indexer");
         System.out.println(
             "  Indexed " + words.size() + " words for document ID=" + document.getId());
+
+        StringBuilder ftsContent = new StringBuilder();
+        ftsContent.append(title).append(" ").append(description).append(" ");
+        for (String word : words) {
+          ftsContent.append(word).append(" ");
+        }
+        databaseHelper.updateFTSEntry(document.getId(), ftsContent.toString().trim());
+
+        ConsoleColors.printInfo("Indexer");
+        System.out.println(
+            "  Updated FTS entry for document ID=" + document.getId() + " in the database");
       }
 
       // Update index time

--- a/src/main/java/com/sherlook/search/indexer/Indexer.java
+++ b/src/main/java/com/sherlook/search/indexer/Indexer.java
@@ -22,6 +22,8 @@ public class Indexer {
   private final PlatformTransactionManager txManager;
   private final Tokenizer tokenizer;
 
+  private static final int BATCH_SIZE = 10000;
+
   @Autowired
   public Indexer(
       DatabaseHelper databaseHelper, PlatformTransactionManager txManager, Tokenizer tokenizer) {
@@ -71,6 +73,7 @@ public class Indexer {
       List<Integer> positions = new ArrayList<>();
       List<Section> sections = new ArrayList<>();
       int pos = 0;
+      int totalWordCount = 0;
 
       if (!title.isEmpty())
         pos =
@@ -84,25 +87,39 @@ public class Indexer {
         Section sec = el.tagName().matches("h[1-6]") ? Section.HEADER : Section.BODY;
         pos =
             tokenizer.tokenizeWithPositions(el.text(), pos, words, stems, positions, sections, sec);
+
+        // Process in batches to avoid going out of memory
+        if (words.size() >= BATCH_SIZE) {
+          processBatch(document.getId(), words, stems, positions, sections);
+          totalWordCount += words.size();
+
+          words.clear();
+          stems.clear();
+          positions.clear();
+          sections.clear();
+        }
       }
 
       // Insert words into the database
       if (!words.isEmpty()) {
-        databaseHelper.batchInsertDocumentWords(
-            document.getId(), words, stems, positions, sections);
+        processBatch(document.getId(), words, stems, positions, sections);
+        totalWordCount += words.size();
+      }
 
-        // Update document's total word count
-        databaseHelper.updateDocumentSize(document.getId(), words.size());
+      // Update document's total word count
+      if (totalWordCount > 0) {
+        databaseHelper.updateDocumentSize(document.getId(), totalWordCount);
 
         ConsoleColors.printInfo("Indexer");
         System.out.println(
-            "  Indexed " + words.size() + " words for document ID=" + document.getId());
+            "  Indexed " + totalWordCount + " words for document ID=" + document.getId());
+        long elapsed = System.currentTimeMillis() - startTime;
+        ConsoleColors.printSuccess("Indexer");
+        System.out.println("Indexing completed in " + elapsed + " ms");
 
         StringBuilder ftsContent = new StringBuilder();
-        ftsContent.append(title).append(" ").append(description).append(" ");
-        for (String word : words) {
-          ftsContent.append(word).append(" ");
-        }
+        ftsContent.append(title).append(" ").append(description);
+
         databaseHelper.updateFTSEntry(document.getId(), ftsContent.toString().trim());
 
         ConsoleColors.printInfo("Indexer");
@@ -113,10 +130,6 @@ public class Indexer {
       // Update index time
       databaseHelper.updateIndexTime(document.getId());
 
-      long elapsed = System.currentTimeMillis() - startTime;
-      ConsoleColors.printSuccess("Indexer");
-      System.out.println("Indexing completed in " + elapsed + " ms");
-
       txManager.commit(status);
     } catch (Exception e) {
       txManager.rollback(status);
@@ -126,6 +139,25 @@ public class Indexer {
               + document.getId()
               + ", rolled back. Cause: "
               + e.getMessage());
+    }
+  }
+
+  private void processBatch(
+      int documentId,
+      List<String> words,
+      List<String> stems,
+      List<Integer> positions,
+      List<Section> sections) {
+    try {
+      if (!words.isEmpty()) {
+        databaseHelper.batchInsertDocumentWords(documentId, words, stems, positions, sections);
+        ConsoleColors.printInfo("Indexer");
+        System.out.println("  Processed batch of " + words.size() + " words");
+      }
+    } catch (Exception e) {
+      ConsoleColors.printError("Indexer");
+      System.err.println("Error processing batch: " + e.getMessage());
+      throw e;
     }
   }
 

--- a/src/main/java/com/sherlook/search/query/QueryProcessor.java
+++ b/src/main/java/com/sherlook/search/query/QueryProcessor.java
@@ -1,17 +1,21 @@
 package com.sherlook.search.query;
 
-import com.sherlook.search.indexer.Tokenizer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import com.sherlook.search.indexer.Tokenizer;
+import com.sherlook.search.utils.ConsoleColors;
 
 @Component
 public class QueryProcessor {
 
-  @Autowired private Tokenizer tokenizer;
+  @Autowired
+  private Tokenizer tokenizer;
 
   boolean isPhraseMatching;
   String[] phrases;
@@ -31,23 +35,75 @@ public class QueryProcessor {
 
   // Processes a user search query.
   public void processQuery(String query) {
-    System.out.println("Processing query: " + query);
     if (query == null || query.trim().isEmpty()) {
+      ConsoleColors.printWarning("QueryProcessor");
+      System.out.println("Empty query received");
       return;
     }
 
     query = query.trim();
 
+    ConsoleColors.printInfo("QueryProcessor");
+    System.out.println(
+        "Processing query: " + ConsoleColors.BOLD_CYAN + query + ConsoleColors.RESET);
+
     if (query.equals(lastQuery)) {
+      ConsoleColors.printInfo("QueryProcessor");
+      System.out.println("Using cached results for query: " + query);
       return;
     } else {
       lastQuery = query;
     }
 
     if (query.matches("\".*\"")) {
+      ConsoleColors.printInfo("QueryProcessor");
+      System.out.println(
+          "Detected "
+              + ConsoleColors.BOLD_YELLOW
+              + "phrase search"
+              + ConsoleColors.RESET
+              + " query");
       parsePhrases(query);
     } else {
+      ConsoleColors.printInfo("QueryProcessor");
+      System.out.println(
+          "Detected "
+              + ConsoleColors.BOLD_GREEN
+              + "keyword search"
+              + ConsoleColors.RESET
+              + " query");
       parseTokens(query);
+    }
+
+    if (isPhraseMatching) {
+      ConsoleColors.printInfo("QueryProcessor");
+      System.out.print("Phrases: ");
+      for (int i = 0; i < phrases.length && phrases[i] != null; i++) {
+        System.out.print(ConsoleColors.BOLD_CYAN + phrases[i] + ConsoleColors.RESET);
+        if (i < phrases.length - 1 && phrases[i + 1] != null) {
+          String op = "?";
+          switch (operators[i]) {
+            case 1:
+              op = "AND";
+              break;
+            case 2:
+              op = "OR";
+              break;
+            case 3:
+              op = "NOT";
+              break;
+          }
+          System.out.print(" " + ConsoleColors.BOLD_PURPLE + op + ConsoleColors.RESET + " ");
+        }
+      }
+      System.out.println();
+    } else {
+      ConsoleColors.printInfo("QueryProcessor");
+      System.out.println(
+          "Tokens: " + ConsoleColors.BOLD_CYAN + String.join(", ", tokens) + ConsoleColors.RESET);
+      ConsoleColors.printInfo("QueryProcessor");
+      System.out.println(
+          "Stems: " + ConsoleColors.BOLD_GREEN + String.join(", ", stems) + ConsoleColors.RESET);
     }
   }
 

--- a/src/main/java/com/sherlook/search/query/QueryProcessor.java
+++ b/src/main/java/com/sherlook/search/query/QueryProcessor.java
@@ -1,21 +1,18 @@
 package com.sherlook.search.query;
 
+import com.sherlook.search.indexer.Tokenizer;
+import com.sherlook.search.utils.ConsoleColors;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import com.sherlook.search.indexer.Tokenizer;
-import com.sherlook.search.utils.ConsoleColors;
 
 @Component
 public class QueryProcessor {
 
-  @Autowired
-  private Tokenizer tokenizer;
+  @Autowired private Tokenizer tokenizer;
 
   boolean isPhraseMatching;
   String[] phrases;

--- a/src/main/java/com/sherlook/search/ranker/Ranker.java
+++ b/src/main/java/com/sherlook/search/ranker/Ranker.java
@@ -2,7 +2,14 @@ package com.sherlook.search.ranker;
 
 import com.sherlook.search.utils.ConsoleColors;
 import com.sherlook.search.utils.DatabaseHelper;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -160,10 +167,10 @@ public class Ranker {
 
       // check convergence
       if (maxDiff < CONVERGENCE_THRESHOLD) {
-        ConsoleColors.printSuccess("PageRank");
+        ConsoleColors.printSuccess("Ranker");
         System.out.println("Converged after " + (i + 1) + " iterations with max diff: " + maxDiff);
 
-        ConsoleColors.printSuccess("PageRank");
+        ConsoleColors.printSuccess("Ranker");
         System.out.println("Convergence threshold: " + CONVERGENCE_THRESHOLD);
         converged = true;
         break;
@@ -173,13 +180,14 @@ public class Ranker {
     }
 
     if (!converged) {
+      ConsoleColors.printWarning("Ranker");
       System.out.println("PageRank did not converge after " + MAX_ITERATIONS + " iterations");
     }
     return pageRankPrevious;
   }
 
   public void rankPagesByPopularity() {
-    ConsoleColors.printSuccess("PageRank");
+    ConsoleColors.printSuccess("Ranker");
     System.out.println("Started ranking pages by popularity");
 
     long start = System.currentTimeMillis();
@@ -188,16 +196,16 @@ public class Ranker {
     List<Link> links = databaseHelper.getLinks();
     Map<Integer, Double> pageRankScores = computePageRank(docIds, links);
 
-    ConsoleColors.printSuccess("PageRank");
+    ConsoleColors.printSuccess("Ranker");
     System.out.println("PageRank scores computed");
 
-    ConsoleColors.printSuccess("PageRank");
+    ConsoleColors.printSuccess("Ranker");
     System.out.println("Updating PageRank scores in the database");
     databaseHelper.batchUpdatePageRank(pageRankScores);
-    ConsoleColors.printSuccess("PageRank");
+    ConsoleColors.printSuccess("Ranker");
     System.out.println("PageRank scores updated in the database");
 
-    ConsoleColors.printSuccess("PageRank");
+    ConsoleColors.printSuccess("Ranker");
     System.out.println(
         "Ranking pages completed in " + (System.currentTimeMillis() - start) + " ms");
   }
@@ -327,9 +335,27 @@ public class Ranker {
 
   public RankingResult rankAndStoreTotalDocuments(List<String> queryTerms, Boolean isPhraseSearch) {
     long start = System.currentTimeMillis();
+    ConsoleColors.printInfo("Ranker");
     System.out.println(
-        "Ranking documents for query INSIDE RANKER: " + String.join(" ", queryTerms));
+        "Starting ranking for "
+            + (isPhraseSearch
+                ? ConsoleColors.BOLD_YELLOW + "phrase search"
+                : ConsoleColors.BOLD_GREEN + "keyword search")
+            + ConsoleColors.RESET
+            + ": "
+            + ConsoleColors.BOLD_CYAN
+            + String.join(" ", queryTerms)
+            + ConsoleColors.RESET);
+
     List<DocumentTerm> documentTerms = databaseHelper.getDocumentTerms(queryTerms);
+
+    ConsoleColors.printInfo("Ranker");
+    System.out.println(
+        "Found "
+            + ConsoleColors.BOLD_CYAN
+            + documentTerms.size()
+            + ConsoleColors.RESET
+            + " document terms matching the query");
 
     List<RankedDocument> tfIdfDocs;
     if (isPhraseSearch) {
@@ -337,6 +363,14 @@ public class Ranker {
     } else {
       tfIdfDocs = getDocumentTfIdf(queryTerms, documentTerms);
     }
+
+    ConsoleColors.printInfo("Ranker");
+    System.out.println(
+        "Calculated TF-IDF scores for "
+            + ConsoleColors.BOLD_CYAN
+            + tfIdfDocs.size()
+            + ConsoleColors.RESET
+            + " documents");
 
     // Apply PageRank
     List<Integer> docIds =
@@ -354,13 +388,27 @@ public class Ranker {
     tfIdfDocs.sort((d1, d2) -> Double.compare(d2.getFinalScore(), d1.getFinalScore()));
 
     long end = System.currentTimeMillis();
-    System.out.println("Ranking time: " + (end - start) + " ms");
+    ConsoleColors.printSuccess("Ranker");
+    System.out.println(
+        "Ranking completed in "
+            + ConsoleColors.BOLD_GREEN
+            + (end - start)
+            + "ms"
+            + ConsoleColors.RESET
+            + " - Found "
+            + ConsoleColors.BOLD_CYAN
+            + tfIdfDocs.size()
+            + ConsoleColors.RESET
+            + " documents");
 
     return new RankingResult(tfIdfDocs, documentTerms);
   }
 
   public RankingResult rankAndStoreTotalDocumentsPhrases(String[] phrases, int[] operators) {
     long start = System.currentTimeMillis();
+    ConsoleColors.printInfo("Ranker");
+    System.out.println("Starting phrase ranking with logical operators");
+
     List<RankedDocument> finalDocs = new ArrayList<>();
 
     // Handle phrase search with operators
@@ -371,13 +419,37 @@ public class Ranker {
     long phraseStart = System.currentTimeMillis();
     for (int i = 0; i < phrases.length && phrases[i] != null; i++) {
       List<String> queryTerms = Arrays.asList(phrases[i].split("\\s+"));
+      ConsoleColors.printInfo("Ranker");
+      System.out.println(
+          "Processing phrase "
+              + (i + 1)
+              + ": "
+              + ConsoleColors.BOLD_CYAN
+              + phrases[i]
+              + ConsoleColors.RESET);
+
       List<DocumentTerm> documentTerms = databaseHelper.getDocumentTerms(queryTerms);
       List<RankedDocument> phraseDocs = getDocumentTfIdfPhrases(queryTerms, documentTerms);
       allDocumentTerms.addAll(documentTerms);
       docIdSets.add(phraseDocs.stream().map(RankedDocument::getDocId).collect(Collectors.toSet()));
+
+      ConsoleColors.printInfo("Ranker");
+      System.out.println(
+          "Found "
+              + ConsoleColors.BOLD_CYAN
+              + phraseDocs.size()
+              + ConsoleColors.RESET
+              + " documents for phrase: "
+              + phrases[i]);
     }
     long phraseEnd = System.currentTimeMillis();
-    System.out.println("Phrase processing time: " + (phraseEnd - phraseStart) + " ms");
+    ConsoleColors.printInfo("Ranker");
+    System.out.println(
+        "Phrase processing completed in "
+            + ConsoleColors.BOLD_CYAN
+            + (phraseEnd - phraseStart)
+            + "ms"
+            + ConsoleColors.RESET);
 
     // Apply logical operators
     Set<Integer> resultDocIds = new HashSet<>();
@@ -436,7 +508,18 @@ public class Ranker {
     finalDocs.sort((d1, d2) -> Double.compare(d2.getFinalScore(), d1.getFinalScore()));
 
     long end = System.currentTimeMillis();
-    System.out.println("Ranking time: " + (end - start) + " ms");
+    ConsoleColors.printSuccess("Ranker");
+    System.out.println(
+        "Ranking completed in "
+            + ConsoleColors.BOLD_GREEN
+            + (end - start)
+            + "ms"
+            + ConsoleColors.RESET
+            + " - Found "
+            + ConsoleColors.BOLD_CYAN
+            + finalDocs.size()
+            + ConsoleColors.RESET
+            + " documents");
 
     return new RankingResult(finalDocs, allDocumentTerms);
   }
@@ -454,6 +537,8 @@ public class Ranker {
             .filter(term -> docIds.contains(term.getDocumentId()))
             .collect(Collectors.toList());
     long filterEnd = System.currentTimeMillis();
+
+    ConsoleColors.printInfo("Ranker");
     System.out.println("Filtering relevant terms time: " + (filterEnd - filterStart) + " ms");
 
     // Measure time for position calculation
@@ -479,6 +564,8 @@ public class Ranker {
       }
     }
     long positionEnd = System.currentTimeMillis();
+
+    ConsoleColors.printInfo("Ranker");
     System.out.println("Finding positions time: " + (positionEnd - positionStart) + " ms");
 
     // Measure database call time
@@ -486,6 +573,8 @@ public class Ranker {
     Map<Integer, Map<Integer, String>> surroundingWords =
         databaseHelper.getWordsAroundPositions(docPositions, 10);
     long dbEnd = System.currentTimeMillis();
+
+    ConsoleColors.printInfo("Ranker");
     System.out.println("Database call for surrounding words: " + (dbEnd - dbStart) + " ms");
 
     // Measure snippet creation time
@@ -521,9 +610,13 @@ public class Ranker {
       doc.setSnippet(snippet.toString());
     }
     long snippetEnd = System.currentTimeMillis();
+
+    ConsoleColors.printInfo("Ranker");
     System.out.println("Snippet creation time: " + (snippetEnd - snippetStart) + " ms");
 
     long totalEnd = System.currentTimeMillis();
+
+    ConsoleColors.printInfo("Ranker");
     System.out.println("Total snippet generation time: " + (totalEnd - totalStart) + " ms");
   }
 

--- a/src/main/java/com/sherlook/search/ranker/Ranker.java
+++ b/src/main/java/com/sherlook/search/ranker/Ranker.java
@@ -327,7 +327,8 @@ public class Ranker {
 
   public RankingResult rankAndStoreTotalDocuments(List<String> queryTerms, Boolean isPhraseSearch) {
     long start = System.currentTimeMillis();
-
+    System.out.println(
+        "Ranking documents for query INSIDE RANKER: " + String.join(" ", queryTerms));
     List<DocumentTerm> documentTerms = databaseHelper.getDocumentTerms(queryTerms);
 
     List<RankedDocument> tfIdfDocs;
@@ -367,6 +368,7 @@ public class Ranker {
     List<Set<Integer>> docIdSets = new ArrayList<>();
 
     // Process each phrase
+    long phraseStart = System.currentTimeMillis();
     for (int i = 0; i < phrases.length && phrases[i] != null; i++) {
       List<String> queryTerms = Arrays.asList(phrases[i].split("\\s+"));
       List<DocumentTerm> documentTerms = databaseHelper.getDocumentTerms(queryTerms);
@@ -374,6 +376,8 @@ public class Ranker {
       allDocumentTerms.addAll(documentTerms);
       docIdSets.add(phraseDocs.stream().map(RankedDocument::getDocId).collect(Collectors.toSet()));
     }
+    long phraseEnd = System.currentTimeMillis();
+    System.out.println("Phrase processing time: " + (phraseEnd - phraseStart) + " ms");
 
     // Apply logical operators
     Set<Integer> resultDocIds = new HashSet<>();

--- a/src/main/java/com/sherlook/search/web/SearchController.java
+++ b/src/main/java/com/sherlook/search/web/SearchController.java
@@ -62,13 +62,6 @@ public class SearchController {
     return rankingCache.stats();
   }
 
-  @GetMapping("/admin/test")
-  @ResponseBody
-  public String testEndpoint() {
-    System.out.println("Test endpoint hit");
-    return "Server is reachable";
-  }
-
   private SearchResponse getSearchResults(
       String[] phrases,
       int[] operators,

--- a/src/main/java/com/sherlook/search/web/SearchController.java
+++ b/src/main/java/com/sherlook/search/web/SearchController.java
@@ -28,7 +28,6 @@ public class SearchController {
           .maximumSize(3000) // LRU component
           .expireAfterWrite(
               30, TimeUnit.MINUTES) // TTL component (very frequent queries could become stale)
-          .recordStats()
           .build();
 
   @Autowired
@@ -53,13 +52,6 @@ public class SearchController {
 
     return getSearchResults(
         phrases, operators, isPhraseSearch, searchTerms, page, resultsPerPage, startTime);
-  }
-
-  @GetMapping("/admin/cache-stats")
-  @ResponseBody
-  public CacheStats getCacheStats() {
-    System.out.println("Cache stats: " + rankingCache.stats());
-    return rankingCache.stats();
   }
 
   private SearchResponse getSearchResults(

--- a/src/main/java/com/sherlook/search/web/SearchController.java
+++ b/src/main/java/com/sherlook/search/web/SearchController.java
@@ -80,7 +80,8 @@ public class SearchController {
 
     String cacheKey = getCacheKey(searchTerms, isPhraseSearch, operators);
     int offset = (page - 1) * resultsPerPage;
-
+    System.out.println("Search terms: " + searchTerms);
+    System.out.println("Cache key: " + cacheKey);
     List<RankedDocument> results;
     Ranker.RankingResult rankingResult;
 

--- a/src/main/java/com/sherlook/search/web/SearchController.java
+++ b/src/main/java/com/sherlook/search/web/SearchController.java
@@ -1,12 +1,14 @@
 package com.sherlook.search.web;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.sherlook.search.query.QueryProcessor;
 import com.sherlook.search.ranker.RankedDocument;
 import com.sherlook.search.ranker.Ranker;
 import java.util.*;
-import java.util.stream.Collectors;
+import java.util.concurrent.TimeUnit;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,9 +23,13 @@ public class SearchController {
   private final QueryProcessor queryProcessor;
   private final Ranker ranker;
 
-  private final Map<String, Ranker.RankingResult> rankingCache = new HashMap<>();
-  private final Map<String, Long> cacheTimestamps = new HashMap<>();
-  private static final long CACHE_EXPIRY_MS = 120000; // 2 minutes
+  private final Cache<String, Ranker.RankingResult> rankingCache =
+      Caffeine.newBuilder()
+          .maximumSize(3000) // LRU component
+          .expireAfterWrite(
+              30, TimeUnit.MINUTES) // TTL component (very frequent queries could become stale)
+          .recordStats()
+          .build();
 
   @Autowired
   public SearchController(QueryProcessor queryProcessor, Ranker ranker) {
@@ -49,6 +55,20 @@ public class SearchController {
         phrases, operators, isPhraseSearch, searchTerms, page, resultsPerPage, startTime);
   }
 
+  @GetMapping("/admin/cache-stats")
+  @ResponseBody
+  public CacheStats getCacheStats() {
+    System.out.println("Cache stats: " + rankingCache.stats());
+    return rankingCache.stats();
+  }
+
+  @GetMapping("/admin/test")
+  @ResponseBody
+  public String testEndpoint() {
+    System.out.println("Test endpoint hit");
+    return "Server is reachable";
+  }
+
   private SearchResponse getSearchResults(
       String[] phrases,
       int[] operators,
@@ -64,24 +84,16 @@ public class SearchController {
     List<RankedDocument> results;
     Ranker.RankingResult rankingResult;
 
-    if (rankingCache.containsKey(cacheKey)) {
-      long timestamp = cacheTimestamps.getOrDefault(cacheKey, 0L);
-      if (System.currentTimeMillis() - timestamp < CACHE_EXPIRY_MS) {
-        rankingResult = rankingCache.get(cacheKey);
-        results = ranker.getPageWithSnippets(rankingResult, searchTerms, offset, resultsPerPage);
-        return createResponse(
-            results, rankingResult, resultsPerPage, System.currentTimeMillis() - startTime);
-      }
-    }
-
-    // Cache miss or expired
-    if (isPhraseSearch) {
-      rankingResult = ranker.rankAndStoreTotalDocumentsPhrases(phrases, operators);
-    } else {
-      rankingResult = ranker.rankAndStoreTotalDocuments(searchTerms, isPhraseSearch);
-    }
-    rankingCache.put(cacheKey, rankingResult);
-    cacheTimestamps.put(cacheKey, System.currentTimeMillis());
+    rankingResult =
+        rankingCache.get(
+            cacheKey,
+            key -> {
+              if (isPhraseSearch) {
+                return ranker.rankAndStoreTotalDocumentsPhrases(phrases, operators);
+              } else {
+                return ranker.rankAndStoreTotalDocuments(searchTerms, isPhraseSearch);
+              }
+            });
 
     results = ranker.getPageWithSnippets(rankingResult, searchTerms, offset, resultsPerPage);
     return createResponse(
@@ -134,21 +146,6 @@ public class SearchController {
       return terms;
     } else {
       return queryProcessor.getTokens();
-    }
-  }
-
-  @Scheduled(fixedRate = 60000) // Run every minute
-  public void cleanupExpiredCache() {
-    long currentTime = System.currentTimeMillis();
-    List<String> keysToRemove =
-        cacheTimestamps.entrySet().stream()
-            .filter(entry -> currentTime - entry.getValue() >= CACHE_EXPIRY_MS)
-            .map(Map.Entry::getKey)
-            .collect(Collectors.toList());
-
-    for (String key : keysToRemove) {
-      rankingCache.remove(key);
-      cacheTimestamps.remove(key);
     }
   }
 

--- a/src/main/java/com/sherlook/search/web/SearchController.java
+++ b/src/main/java/com/sherlook/search/web/SearchController.java
@@ -2,7 +2,6 @@ package com.sherlook.search.web;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.sherlook.search.query.QueryProcessor;
 import com.sherlook.search.ranker.RankedDocument;
 import com.sherlook.search.ranker.Ranker;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -37,6 +37,13 @@ CREATE TABLE IF NOT EXISTS links (
     PRIMARY KEY(source_document_id, target_url)
 );
 
-CREATE INDEX IF NOT EXISTS idx_document_words_covering ON document_words(word_id, document_id, section, position);
-CREATE INDEX IF NOT EXISTS idx_document_words ON document_words(document_id);
-CREATE INDEX IF NOT EXISTS idx_words ON words(word);
+CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
+    title,
+    description,
+    content
+);
+
+
+CREATE INDEX IF NOT EXISTS idx_documents_wid_docid ON document_words(word_id, document_id);
+CREATE INDEX IF NOT EXISTS idx_document_words ON document_words(word_id);
+CREATE INDEX IF NOT EXISTS idx_documents_documents ON document_words(document_id);


### PR DESCRIPTION
## 🛠️ Enhancements & Optimizations

- **Optimized the real‑time search functionality** through a more robust flow for the database trips
  - Using FTS to get the candidate document ids  
  - Getting word ids  
  - Added a composite index `(word_id, document_id)` on the document_words table for efficient filtering
  - Now this is interesting, the `sqlite query planner` didn’t actually pick the best plan for the last query (normally the join happens before the filter (`WHERE`)), so I had to force it (through a subquery) to first filter the large table by the candidate doc ids and word ids we got, then perform the join to get the actual documents and the relevant data.  
  - This was the main idea for optimization; I used temp tables because it’s impossible to have a very large `IN (…)` clause in the `WHERE` (typically candidate doc ids are thousands), so the temp tables simulate the “filtering” logic.


- **Caching improvements**
  - Added an LRU cache used with a hybrid TTL mechanism, opposed to previously relying only on TTL caching  
  - The reason it’s not a pure LRU is that some queries can be very frequently visited, and we normally have periodic crawls and index cycles, so results may become stale  
  - I used Caffeine (highly concurrent, “near‑optimal” eviction) instead of a custom `LinkedHashMap`  
